### PR TITLE
gtpl.Open(string) changed to variadic gtpl.Open(...interface{}) to accept a file path as a string, or a byte slice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2018 Sam
+Copyright (c) 2022 Matt Rienzo, where marked in file headers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/example/go.mod
+++ b/example/go.mod
@@ -2,4 +2,4 @@ module example/runme
 
 go 1.18
 
-require github.com/casnix/gtpl v0.0.1-2
+require github.com/casnix/gtpl v0.0.2 // indirect

--- a/example/go.mod
+++ b/example/go.mod
@@ -2,4 +2,4 @@ module example/runme
 
 go 1.18
 
-require github.com/casnix/gtpl v0.0.2
+require github.com/casnix/gtpl v1.0.0

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,0 +1,5 @@
+module example/runme
+
+go 1.18
+
+require github.com/casnix/gtpl v0.0.0-20220721185816-4087cf5fff91 // indirect

--- a/example/go.mod
+++ b/example/go.mod
@@ -2,4 +2,4 @@ module example/runme
 
 go 1.18
 
-require github.com/casnix/gtpl v0.0.2 // indirect
+require github.com/casnix/gtpl v0.0.2

--- a/example/go.mod
+++ b/example/go.mod
@@ -2,4 +2,4 @@ module example/runme
 
 go 1.18
 
-require github.com/casnix/gtpl v0.0.1
+require github.com/casnix/gtpl v0.0.1-2

--- a/example/go.mod
+++ b/example/go.mod
@@ -2,4 +2,4 @@ module example/runme
 
 go 1.18
 
-require github.com/casnix/gtpl v0.0.0-20220721185816-4087cf5fff91 // indirect
+require github.com/casnix/gtpl v0.0.1

--- a/example/go.sum
+++ b/example/go.sum
@@ -1,2 +1,2 @@
-github.com/casnix/gtpl v0.0.0-20220721185816-4087cf5fff91 h1:Qvdy9kxuDXCBbOW2x9laBAs5yfzPg6R5KcFvSY/2HHY=
-github.com/casnix/gtpl v0.0.0-20220721185816-4087cf5fff91/go.mod h1:OHpHhxmaUtZSXNnIG1OpbocnldSF6liiQsDE6rUtS0A=
+github.com/casnix/gtpl v0.0.1 h1:06+XYNZgaJe9t1t9f34dIz3GAyEWHfBMxxoQu7ZSVHA=
+github.com/casnix/gtpl v0.0.1/go.mod h1:OHpHhxmaUtZSXNnIG1OpbocnldSF6liiQsDE6rUtS0A=

--- a/example/go.sum
+++ b/example/go.sum
@@ -1,2 +1,2 @@
-github.com/casnix/gtpl v0.0.1 h1:06+XYNZgaJe9t1t9f34dIz3GAyEWHfBMxxoQu7ZSVHA=
-github.com/casnix/gtpl v0.0.1/go.mod h1:OHpHhxmaUtZSXNnIG1OpbocnldSF6liiQsDE6rUtS0A=
+github.com/casnix/gtpl v0.0.2 h1:vBcTZppfRoehFXh4EOLeBBF8NWz00SfpfR6XgXyOo1o=
+github.com/casnix/gtpl v0.0.2/go.mod h1:OHpHhxmaUtZSXNnIG1OpbocnldSF6liiQsDE6rUtS0A=

--- a/example/go.sum
+++ b/example/go.sum
@@ -1,0 +1,2 @@
+github.com/casnix/gtpl v0.0.0-20220721185816-4087cf5fff91 h1:Qvdy9kxuDXCBbOW2x9laBAs5yfzPg6R5KcFvSY/2HHY=
+github.com/casnix/gtpl v0.0.0-20220721185816-4087cf5fff91/go.mod h1:OHpHhxmaUtZSXNnIG1OpbocnldSF6liiQsDE6rUtS0A=

--- a/example/go.sum
+++ b/example/go.sum
@@ -1,2 +1,2 @@
-github.com/casnix/gtpl v0.0.1-1 h1:W4BHcVpE0Ka9krE8q5n7XniE7fdxDXnlkJmodF0+d+0=
-github.com/casnix/gtpl v0.0.1-1/go.mod h1:OHpHhxmaUtZSXNnIG1OpbocnldSF6liiQsDE6rUtS0A=
+github.com/casnix/gtpl v0.0.1 h1:06+XYNZgaJe9t1t9f34dIz3GAyEWHfBMxxoQu7ZSVHA=
+github.com/casnix/gtpl v0.0.1/go.mod h1:OHpHhxmaUtZSXNnIG1OpbocnldSF6liiQsDE6rUtS0A=

--- a/example/go.sum
+++ b/example/go.sum
@@ -1,2 +1,2 @@
-github.com/casnix/gtpl v0.0.1 h1:06+XYNZgaJe9t1t9f34dIz3GAyEWHfBMxxoQu7ZSVHA=
-github.com/casnix/gtpl v0.0.1/go.mod h1:OHpHhxmaUtZSXNnIG1OpbocnldSF6liiQsDE6rUtS0A=
+github.com/casnix/gtpl v0.0.1-1 h1:W4BHcVpE0Ka9krE8q5n7XniE7fdxDXnlkJmodF0+d+0=
+github.com/casnix/gtpl v0.0.1-1/go.mod h1:OHpHhxmaUtZSXNnIG1OpbocnldSF6liiQsDE6rUtS0A=

--- a/example/runme.go
+++ b/example/runme.go
@@ -3,6 +3,7 @@
 /*                                                               */
 /*---------------------------------------------------------------*/
 /* Copyright (c) 2018 Sam                                        */
+/* Copyright (c) 2022 Matt Rienzo                                */
 /*                                                               */
 /* MIT Licensed:                                                 */
 /* Permission is hereby granted, free of charge, to any person   */
@@ -32,7 +33,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/protosam/gtpl"
+	"github.com/casnix/gtpl"
+	"io/ioutil"
 	"log"
 )
 
@@ -47,7 +49,11 @@ func main() {
 	log.Println("Hello TPL!")
 
 	// Use the main.html template or die
-	tpl, err := gtpl.Open("templates/main.html")
+	mainData, bErr := ioutil.ReadFile("templates/main.html")
+	if bErr != nil {
+		log.Panic(bErr)
+	}
+	tpl, err := gtpl.Open(mainData)
 	if err != nil {
 		log.Panic(err)
 	}

--- a/example/runme.go
+++ b/example/runme.go
@@ -49,6 +49,8 @@ func main() {
 	log.Println("Hello TPL!")
 
 	// Use the main.html template or die
+	// Pass file directly to gtpl.Open() as a byte slice
+	// instead of having gtpl.Open() read the file
 	mainData, bErr := ioutil.ReadFile("templates/main.html")
 	if bErr != nil {
 		log.Panic(bErr)
@@ -84,6 +86,7 @@ func main() {
 
 // Handler to parse out page headers
 func header_handler() string {
+	// Pass filename as string to gtpl.Open()
 	tpl, err := gtpl.Open("templates/overall.html")
 	if err != nil {
 		log.Println(err)

--- a/example/runme.go
+++ b/example/runme.go
@@ -1,3 +1,33 @@
+/*****************************************************************/
+/* runme.go -- An example program using GTPL.                    */
+/*                                                               */
+/*---------------------------------------------------------------*/
+/* Copyright (c) 2018 Sam                                        */
+/*                                                               */
+/* MIT Licensed:                                                 */
+/* Permission is hereby granted, free of charge, to any person   */
+/* obtaining a copy of this software and associated documentation*/
+/* files (the "Software"), to deal in the Software without       */
+/* restriction, including without limitation the rights to use,  */
+/* copy, modify, merge, publish, distribute, sublicense, and/or  */
+/* sell copies of the Software, and to permit persons to whom the*/
+/* Software is furnished to do so, subject to the following      */
+/* conditions:                                                   */
+/*                                                               */
+/* The above copyright notice and this permission notice shall   */
+/* be included in all copies or substantial portions of the      */
+/* Software.                                                     */
+/*                                                               */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY     */
+/* KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE    */
+/* WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR       */
+/* PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR */
+/* COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER   */
+/* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR          */
+/* OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.        */
+/*****************************************************************/
+
 package main
 
 import (

--- a/gtpl.go
+++ b/gtpl.go
@@ -60,7 +60,7 @@ type TPL struct {
 //        TPL object				-- Contains TPL data about GTPL file
 //        error                     -- Returned if parser fails to parse TPL data or paramaters are wrong
 func Open(vArgs ...interface{}) (TPL, error) {
-	filePath, fileStream, pErrs := openParams(vArgs)
+	filePath, fileStream, pErrs := openParams(vArgs...)
 
 	if pErrs != nil {
 		return TPL{}, pErrs

--- a/gtpl.go
+++ b/gtpl.go
@@ -110,16 +110,14 @@ func openParams(vArgs ...interface{}) (filePath string, fileStream []byte, err e
 	}
 
 	// Validate and unload arguments
+	var check1 bool
+	var check2 bool
 	for _,param := range vArgs {
-		switch x := param.(type) {
-		case []byte:
-			fileStream, _ = param.([]byte)
+		fileStream, check1 = param.([]byte)
+		filePath, check2 = param.(string)
+		if !check1 && !check2 {
+			err = errors.New(fmt.Sprintf("invalid type: %T", param))
 			return
-		case string:
-			filePath, _ = param.(string)
-			return
-		default:
-			err = errors.New(fmt.Sprintf("invalid type: %T", x))
 		}
 	}
 

--- a/gtpl.go
+++ b/gtpl.go
@@ -100,30 +100,26 @@ func Open(vArgs ...interface{}) (TPL, error) {
 //     OR fileStream []byte			-- untouched
 //        err         error			-- set if incorrect number of arguments are passed
 func openParams(vArgs ...interface{}) (filePath string, fileStream []byte, err error) {
+	filePath, fileStream = "", []byte{}
+	
 	// Verify enough parameters
 	if 1 > len(vArgs) {
 		err = errors.New("not enough parameters")
+	} else if 1 < len(vArgs) {
+		err = errors.New("too many parameters")
 	}
 
 	// Validate and unload arguments
-	for i,p := range vArgs {
-		switch i {
-		case 0: // filePath or fileStream
-			pString, check1 := p.(string)
-			pBytes, check2 := p.([]byte)
-			if !check1 && !check2 {
-				err = errors.New("1st parameter not type string or []byte")
-				return
-			}
-			
-			if !check1 {
-				fileStream = pBytes
-			} else if !check2 {
-				filePath = pString
-			}
-		default:
-			err = errors.New("too many parameters")
+	for _,param := range vArgs {
+		switch x := param.(type) {
+		case []byte:
+			fileStream, _ = param.([]byte)
 			return
+		case string:
+			filePath, _ = param.(string)
+			return
+		default:
+			err = errors.New(fmt.Sprintf("invalid type: %T", x))
 		}
 	}
 


### PR DESCRIPTION
I changed gtpl.Open() to a variadic function that can accept the file path as a string, or the file data as a byte slice.  This was to solve a problem in one of my projects where I am reading GTPL files from a TGZ archive held in memory.  I have also added comments to the top of the files I modified that show your copyright, mine, and the MIT license.

This fixes issue #1 .